### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,5 +1,6 @@
 requires 'perl', '5.008001';
 requires 'Git::Repository', '1.14';
+requires 'Test::Requires::Git', '1.005';
 
 on 'test' => sub {
     requires 'Test::More', '0.98';

--- a/t/has_ref.t
+++ b/t/has_ref.t
@@ -5,11 +5,12 @@ use File::Spec qw();
 use IO::File qw();
 
 use Git::Repository qw(Info);
-use Test::Git qw(has_git test_repository);
+use Test::Git qw(test_repository);
+use Test::Requires::Git;
 
 use Test::More;
 
-has_git();
+test_requires_git();
 plan tests => 4;
 
 do {

--- a/t/is_bare.t
+++ b/t/is_bare.t
@@ -1,12 +1,13 @@
 use strict;
 use warnings;
 
-use Test::Git qw(has_git test_repository);
+use Test::Git qw(test_repository);
+use Test::Requires::Git;
 use Git::Repository qw(Info);
 
 use Test::More;
 
-has_git();
+test_requires_git();
 plan tests => 2;
 
 do {


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
